### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 log.html
 .env
 .DS_Store
+/.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterHCL",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterHCL", targets: ["TreeSitterHCL"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterHCL",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "CHANGELOG.md",
+                    "docs",
+                    "example",
+                    "grammar.js",
+                    "LICENSE",
+                    "package.json",
+                    "README.md",
+                    "shell.nix",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                    "test",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.cc",
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")],
+                linkerSettings: [.linkedLibrary("c++")])
+    ]
+)

--- a/bindings/swift/TreeSitterHCL/hcl.h
+++ b/bindings/swift/TreeSitterHCL/hcl.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_HCL_H_
+#define TREE_SITTER_HCL_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_hcl();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_HCL_H_


### PR DESCRIPTION
This adds Swift bindings and Swift Package Manager (SPM) support. I maintain the tree-sitter Swift binding here https://github.com/chimeHQ/SwiftTreeSitter

Here are some examples of other PRs:

tree-sitter/tree-sitter-go#79
tree-sitter/tree-sitter-c#105
tree-sitter/tree-sitter-haskell#91

These are manually created. They should not ever impact the parser. There no need for you to publish packages or take action for releases. The exclude patterns are pretty safe to get out of sync. They can, in some circumstances, generate warnings for Swift users. But, it's really minor.

Oh, and thanks for making this. It's awesome!