### PR TITLE
Add a shim to move a comment extra into a body node

### DIFF
--- a/make_grammar.js
+++ b/make_grammar.js
@@ -37,12 +37,15 @@ module.exports = function make_grammar(dialect) {
       // also allow objects to handle .tfvars in json format
       config_file: $ => optional(choice($.body, $.object)),
 
-      body: $ => seq(
-        optional($._shim),
-        repeat1(
-          choice(
-            $.attribute,
-            $.block,
+      body: $ => choice(
+        $._shim,
+        seq(
+          optional($._shim),
+          repeat1(
+            choice(
+              $.attribute,
+              $.block,
+            ),
           ),
         ),
       ),

--- a/make_grammar.js
+++ b/make_grammar.js
@@ -25,6 +25,7 @@ module.exports = function make_grammar(dialect) {
       $.template_directive_start,
       $.template_directive_end,
       $.heredoc_identifier,
+      $._shim,
     ],
 
     extras: $ => [
@@ -36,10 +37,13 @@ module.exports = function make_grammar(dialect) {
       // also allow objects to handle .tfvars in json format
       config_file: $ => optional(choice($.body, $.object)),
 
-      body: $ => repeat1(
-        choice(
-          $.attribute,
-          $.block,
+      body: $ => seq(
+        optional($._shim),
+        repeat1(
+          choice(
+            $.attribute,
+            $.block,
+          ),
         ),
       ),
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -98,6 +98,8 @@ public:
       return false;
     }
     if (valid_symbols[SHIM]) {
+      lexer->mark_end(lexer);
+      while(skip_comment(lexer));
       if (lexer->lookahead != '}') {
         return accept_inplace(lexer, SHIM);
       }
@@ -269,6 +271,20 @@ private:
   bool consume_wxdigit(TSLexer *lexer) {
     advance(lexer);
     return iswxdigit(lexer->lookahead);
+  }
+
+  bool skip_comment(TSLexer* lexer) {
+    while (iswspace(lexer->lookahead)) {
+      skip(lexer);
+    }
+    if (lexer->lookahead != '#') {
+      return false;
+    }
+    skip(lexer);
+    while (lexer->lookahead != '\n') {
+      skip(lexer);
+    }
+    return true;
   }
 
   bool in_context_type(ContextType type) {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -20,6 +20,7 @@ enum TokenType {
   TEMPLATE_DIRECTIVE_START,
   TEMPLATE_DIRECTIVE_END,
   HEREDOC_IDENTIFIER,
+  SHIM,
 };
 
 enum ContextType {
@@ -95,6 +96,11 @@ public:
     }
     if (lexer->lookahead == '\0') {
       return false;
+    }
+    if (valid_symbols[SHIM]) {
+      if (lexer->lookahead != '}') {
+        return accept_inplace(lexer, SHIM);
+      }
     }
     // manage quoted context
     if (valid_symbols[QUOTED_TEMPLATE_START] && !in_quoted_context() &&


### PR DESCRIPTION
A demo of the concept how to cheat parser and move a comment extra node inside of a body node.
<details><summary>Screenshot</summary>

![Screenshot from 2023-04-08 07-02-02](https://user-images.githubusercontent.com/14666676/230702306-c1ca63f2-33dc-4cdd-a2bd-4c7de754da3a.png)
</details>

Closes #30 