### PR TITLE
fix(scanner): fix segfault

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,8 @@ in
 pkgs.mkShell {
   name = "env";
   buildInputs = with pkgs; [
+    gdb
+    valgrind
     nodejs
     tree-sitter
     emscripten

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -11,6 +11,7 @@
     void *tmp = realloc((vec).data, (_cap) * sizeof((vec).data[0]));           \
     assert(tmp != NULL);                                                       \
     (vec).data = tmp;                                                          \
+    assert((vec).data != NULL);                                                \
     (vec).cap = (_cap);
 
 #define VEC_PUSH(vec, el)                                                      \
@@ -31,22 +32,23 @@
     {                                                                          \
         if ((vec).data != NULL)                                                \
             free((vec).data);                                                  \
+        (vec).data = NULL;                                                     \
     }
 
 #define VEC_CLEAR(vec)                                                         \
     {                                                                          \
-        for (int i = 0; i < (vec).len; i++) {                                  \
+        for (uint32_t i = 0; i < (vec).len; i++) {                             \
             STRING_FREE((vec).data[i].heredoc_identifier);                     \
         }                                                                      \
         (vec).len = 0;                                                         \
     }
 
 #define STRING_RESIZE(vec, _cap)                                               \
-    void *tmp = realloc((vec).data, (_cap + 1) * sizeof((vec).data[0]));       \
+    void *tmp = realloc((vec).data, ((_cap) + 1) * sizeof((vec).data[0]));     \
     assert(tmp != NULL);                                                       \
     (vec).data = tmp;                                                          \
     memset((vec).data + (vec).len, 0,                                          \
-           ((_cap + 1) - (vec).len) * sizeof((vec).data[0]));                  \
+           (((_cap) + 1) - (vec).len) * sizeof((vec).data[0]));                \
     (vec).cap = (_cap);
 
 #define STRING_GROW(vec, _cap)                                                 \
@@ -61,10 +63,9 @@
     (vec).data[(vec).len++] = (el);
 
 #define STRING_FREE(vec)                                                       \
-    {                                                                          \
-        if ((vec).data != NULL)                                                \
-            free((vec).data);                                                  \
-    }
+    if ((vec).data != NULL)                                                    \
+        free((vec).data);                                                      \
+    (vec).data = NULL;
 
 enum TokenType {
     QUOTED_TEMPLATE_START,
@@ -105,14 +106,10 @@ typedef struct {
     String heredoc_identifier;
 } Context;
 
-Context context_new(enum ContextType type, const char *data) {
+Context context_new(enum ContextType type) {
     Context ctx = {
         .type = type,
-        .heredoc_identifier = string_new(),
     };
-    ctx.heredoc_identifier.len = strlen(data);
-    ctx.heredoc_identifier.cap = strlen(data);
-    memcpy(ctx.heredoc_identifier.data, data, ctx.heredoc_identifier.len);
     return ctx;
 }
 
@@ -160,8 +157,8 @@ static void deserialize(Scanner *scanner, const char *buffer, unsigned length) {
     if (length == 0) {
         return;
     }
-
     VEC_CLEAR(scanner->context_stack);
+
     unsigned size = 0;
     uint32_t context_stack_size;
     memcpy(&context_stack_size, &buffer[size], sizeof(uint32_t));
@@ -249,7 +246,8 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
     }
     // manage quoted context
     if (valid_symbols[QUOTED_TEMPLATE_START] && !in_quoted_context(scanner) && lexer->lookahead == '"') {
-        Context ctx = context_new(QUOTED_TEMPLATE, "");
+        Context ctx = context_new(QUOTED_TEMPLATE);
+        ctx.heredoc_identifier = string_new();
         VEC_PUSH(scanner->context_stack, ctx);
         return accept_and_advance(lexer, QUOTED_TEMPLATE_START);
     }
@@ -263,7 +261,8 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
         !in_interpolation_context(scanner) && lexer->lookahead == '$') {
         advance(lexer);
         if (lexer->lookahead == '{') {
-            Context ctx = context_new(TEMPLATE_INTERPOLATION, "");
+            Context ctx = context_new(TEMPLATE_INTERPOLATION);
+            ctx.heredoc_identifier = string_new();
             VEC_PUSH(scanner->context_stack, ctx);
             return accept_and_advance(lexer, TEMPLATE_INTERPOLATION_START);
         }
@@ -287,7 +286,8 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
         !in_directive_context(scanner) && lexer->lookahead == '%') {
         advance(lexer);
         if (lexer->lookahead == '{') {
-            Context ctx = context_new(TEMPLATE_DIRECTIVE, "");
+            Context ctx = context_new(TEMPLATE_DIRECTIVE);
+            ctx.heredoc_identifier = string_new();
             VEC_PUSH(scanner->context_stack, ctx);
             return accept_and_advance(lexer, TEMPLATE_DIRECTIVE_START);
         }
@@ -314,7 +314,8 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
             STRING_PUSH(identifier, lexer->lookahead);
             advance(lexer);
         }
-        Context ctx = {HEREDOC_TEMPLATE, identifier};
+        Context ctx = context_new(HEREDOC_TEMPLATE);
+        ctx.heredoc_identifier = identifier;
         VEC_PUSH(scanner->context_stack, ctx);
         return accept_inplace(lexer, HEREDOC_IDENTIFIER);
     }


### PR DESCRIPTION
@amaanq can you have a look please? I copied over the macros from bash and fixed the string handling in the contexts ( i think ).

Valgrind seems happy and gdb seems happy with the repro 

```
$ docker run --env TREE_SITTER_HCL_REF="mhoffm-fix-segfault" -it emacs-29-bugreport-pgtk:latest     gdb --args emacs --batch -l minimal-reproduce.el
GNU gdb (GDB) Fedora Linux 13.2-6.fc38
Copyright (C) 2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from emacs...
(gdb) r
Starting program: /usr/local/bin/emacs --batch -l minimal-reproduce.el
warning: Error disabling address space randomization: Operation not permitted
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Missing separate debuginfo for /lib64/libwayland-client.so.0
Try: dnf --enablerepo='*debug*' install /usr/lib/debug/.build-id/8f/223d7d413dd53824844e75fd05ae04a70176c0.debug
Missing separate debuginfo for /lib64/libwayland-egl.so.1
Try: dnf --enablerepo='*debug*' install /usr/lib/debug/.build-id/f9/f3cc8549fe242cd014a4645b53ca3504d5f25e.debug
Cloning repository
[Detaching after vfork from child process 19]
Compiling library
[Detaching after vfork from child process 30]
[Detaching after vfork from child process 33]
[Detaching after vfork from child process 36]
Library installed to ~/.emacs.d/tree-sitter/libtree-sitter-hcl.so
[Inferior 1 (process 16) exited normally]
Missing separate debuginfos, use: dnf debuginfo-install liblerc-4.0.0-3.fc38.x86_64 lz4-libs-1.9.4-2.fc38.x86_64 ncurses-libs-6.4-3.20230114.fc38.x86_64 nettle-3.8-3.fc38.x86_64 systemd-libs-253.10-1.fc38.x86_64
(gdb)
```

